### PR TITLE
feat(Input)[]: Add `destination-folder` input param to allow for shared repos

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@CherryKatatonic:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@CherryKatatonic:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 
         steps:
         - name: Sync
-          uses: joshcai/leetcode-sync@v1.3
+          uses: CherryKatatonic/leetcode-sync@v1.3
           with:
+            user: name
             github-token: ${{ github.token }}
             leetcode-csrf-token: ${{ secrets.LEETCODE_CSRF_TOKEN }}
             leetcode-session: ${{ secrets.LEETCODE_SESSION }}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 - `leetcode-session` *(required)*: The LeetCode session value for retrieving submissions from LeetCode
 - `filter-duplicate-secs`: Number of seconds after an accepted solution to ignore other accepted solutions for the same problem, default: 86400 (1 day)
 
+## Shared Repos
+
+A single repo can be shared by multiple users by using the `destination-folder` input field to sync each user's files to a separate folder. This is useful for users who want to add a more social, collaborative, or competitive aspect to their LeetCode sync repo.
+
 ## FAQ
 
 #### Job fails with "HttpError: API rate limit exceeded for installation ID \<id\>"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 
         steps:
         - name: Sync
-          uses: CherryKatatonic/leetcode-sync@v1.4
+          uses: joshcai/leetcode-sync@v1.4
           with:
             destination-folder: my-folder
             github-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 
         steps:
         - name: Sync
-          uses: CherryKatatonic/leetcode-sync@v1.3
+          uses: CherryKatatonic/leetcode-sync@v1.4
           with:
             user: name
             github-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
         - name: Sync
           uses: CherryKatatonic/leetcode-sync@v1.4
           with:
-            user: name
+            destination-folder: my-folder
             github-token: ${{ github.token }}
             leetcode-csrf-token: ${{ secrets.LEETCODE_CSRF_TOKEN }}
             leetcode-session: ${{ secrets.LEETCODE_SESSION }}
@@ -57,7 +57,7 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 
 ## Inputs
 
-- `user` *(optional)*: The user to sync (for shared repos)
+- `destination-folder` *(optional)*: The folder in your repo to save the submissions to (necessary for shared repos)
 - `github-token` *(required)*: The GitHub access token for pushing solutions to the repository
 - `leetcode-csrf-token` *(required)*: The LeetCode CSRF token for retrieving submissions from LeetCode
 - `leetcode-session` *(required)*: The LeetCode session value for retrieving submissions from LeetCode

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 
 ## Inputs
 
+- `user` *(optional)*: The user to sync (for shared repos)
 - `github-token` *(required)*: The GitHub access token for pushing solutions to the repository
 - `leetcode-csrf-token` *(required)*: The LeetCode CSRF token for retrieving submissions from LeetCode
 - `leetcode-session` *(required)*: The LeetCode session value for retrieving submissions from LeetCode

--- a/README.md
+++ b/README.md
@@ -45,23 +45,23 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 
         steps:
         - name: Sync
-          uses: joshcai/leetcode-sync@v1.4
+          uses: joshcai/leetcode-sync@v1.3
           with:
-            destination-folder: my-folder
             github-token: ${{ github.token }}
             leetcode-csrf-token: ${{ secrets.LEETCODE_CSRF_TOKEN }}
             leetcode-session: ${{ secrets.LEETCODE_SESSION }}
+            destination-folder: my-folder
     ```
 
 5. Run the workflow by going to the `Actions` tab, clicking the action name, e.g. `Sync Leetcode`, and then clicking `Run workflow`. The workflow will also automatically run once a week by default (can be configured via the `cron` parameter).
 
 ## Inputs
 
-- `destination-folder` *(optional)*: The folder in your repo to save the submissions to (necessary for shared repos)
 - `github-token` *(required)*: The GitHub access token for pushing solutions to the repository
 - `leetcode-csrf-token` *(required)*: The LeetCode CSRF token for retrieving submissions from LeetCode
 - `leetcode-session` *(required)*: The LeetCode session value for retrieving submissions from LeetCode
 - `filter-duplicate-secs`: Number of seconds after an accepted solution to ignore other accepted solutions for the same problem, default: 86400 (1 day)
+- `destination-folder` *(optional)*: The folder in your repo to save the submissions to (necessary for shared repos)
 
 ## Shared Repos
 

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,8 @@ branding:
   icon: git-commit
   color: yellow
 inputs:
-  user:
-    description: 'The user to sync'
+  destination-folder:
+    description: 'The folder to save the synced files in (relative to the top level of your repo)'
     required: false
   github-token:
     description: 'The GitHub token'

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'LeetCode Sync'
+name: 'CherryKatatonic LeetCode Sync'
 description: 'Sync LeetCode submissions to GitHub'
 branding: 
   icon: git-commit

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'CherryKatatonic LeetCode Sync'
+name: 'LeetCode Sync'
 description: 'Sync LeetCode submissions to GitHub'
 branding: 
   icon: git-commit

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ branding:
   icon: git-commit
   color: yellow
 inputs:
-  destination-folder:
-    description: 'The folder to save the synced files in (relative to the top level of your repo)'
-    required: false
   github-token:
     description: 'The GitHub token'
     required: true
@@ -20,6 +17,9 @@ inputs:
     description: 'Number of seconds after an accepted solution to ignore other accepted solutions for the same problem'
     required: false
     default: 86400
+  destination-folder:
+    description: 'The folder to save the synced files in (relative to the top level of your repo)'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: git-commit
   color: yellow
 inputs:
+  user:
+    description: 'The user to sync'
+    required: false
   github-token:
     description: 'The GitHub token'
     required: true

--- a/index.js
+++ b/index.js
@@ -56,9 +56,8 @@ async function commit(params) {
     throw `Language ${submission.lang} does not have a registered extension.`;
   }
 
-  const path = !!destinationFolder
-    ? `${destinationFolder}/problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`
-    : `problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`
+  const prefix = !!destinationFolder ? `${destinationFolder}/` : '';
+  const path = `${prefix}problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`
 
   const treeData = [
     {

--- a/index.js
+++ b/index.js
@@ -56,9 +56,13 @@ async function commit(params) {
     throw `Language ${submission.lang} does not have a registered extension.`;
   }
 
+  const path = !!destinationFolder
+    ? `${destinationFolder}/problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`
+    : `problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`
+
   const treeData = [
     {
-      path: `${destinationFolder}/problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`,
+      path,
       mode: '100644',
       content: submission.code,
     }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function normalizeName(problemName) {
   return problemName.toLowerCase().replace(/\s/g, '_');
 }
 
-async function commit(octokit, destinationFolder, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission) {
+async function commit(octokit, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission, destinationFolder) {
   const name = normalizeName(submission.title);
   log(`Committing solution for ${name}...`);
 
@@ -115,7 +115,7 @@ function addToSubmissions(response, lastTimestamp, filterDuplicateSecs, submissi
   return true;
 }
 
-async function sync(destinationFolder, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession) {
+async function sync(githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession, destinationFolder) {
   const octokit = new Octokit({
     auth: githubToken,
     userAgent: 'LeetCode sync to GitHub - GitHub Action',
@@ -205,7 +205,7 @@ async function sync(destinationFolder, githubToken, owner, repo, filterDuplicate
   let treeSHA = commits.data[0].commit.tree.sha;
   for (i = submissions.length - 1; i >= 0; i--) {
     submission = submissions[i];
-    [treeSHA, latestCommitSHA] = await commit(octokit, destinationFolder, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission);
+    [treeSHA, latestCommitSHA] = await commit(octokit, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission, destinationFolder);
   }
   log('Done syncing all submissions.');
 }
@@ -219,7 +219,7 @@ async function main() {
   const leetcodeSession = core.getInput('leetcode-session');
   const filterDuplicateSecs = core.getInput('filter-duplicate-secs');
 
-  await sync(destinationFolder, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession);
+  await sync(githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession, destinationFolder);
 }
 
 main().catch((error) => {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function normalizeName(problemName) {
   return problemName.toLowerCase().replace(/\s/g, '_');
 }
 
-async function commit(octokit, user, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission) {
+async function commit(octokit, destinationFolder, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission) {
   const name = normalizeName(submission.title);
   log(`Committing solution for ${name}...`);
 
@@ -46,7 +46,7 @@ async function commit(octokit, user, owner, repo, defaultBranch, commitInfo, tre
 
   const treeData = [
     {
-      path: `${user}/problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`,
+      path: `${destinationFolder}/problems/${name}/solution.${LANG_TO_EXTENSION[submission.lang]}`,
       mode: '100644',
       content: submission.code,
     }
@@ -115,7 +115,7 @@ function addToSubmissions(response, lastTimestamp, filterDuplicateSecs, submissi
   return true;
 }
 
-async function sync(user, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession) {
+async function sync(destinationFolder, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession) {
   const octokit = new Octokit({
     auth: githubToken,
     userAgent: 'LeetCode sync to GitHub - GitHub Action',
@@ -205,13 +205,13 @@ async function sync(user, githubToken, owner, repo, filterDuplicateSecs, leetcod
   let treeSHA = commits.data[0].commit.tree.sha;
   for (i = submissions.length - 1; i >= 0; i--) {
     submission = submissions[i];
-    [treeSHA, latestCommitSHA] = await commit(octokit, user, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission);
+    [treeSHA, latestCommitSHA] = await commit(octokit, destinationFolder, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission);
   }
   log('Done syncing all submissions.');
 }
 
 async function main() {
-  const user = core.getInput('user');
+  const destinationFolder = core.getInput('destination-folder');
   const githubToken = core.getInput('github-token');
   const owner = context.repo.owner;
   const repo = context.repo.repo;
@@ -219,7 +219,7 @@ async function main() {
   const leetcodeSession = core.getInput('leetcode-session');
   const filterDuplicateSecs = core.getInput('filter-duplicate-secs');
 
-  await sync(user, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession);
+  await sync(destinationFolder, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession);
 }
 
 main().catch((error) => {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function normalizeName(problemName) {
   return problemName.toLowerCase().replace(/\s/g, '_');
 }
 
-async function commit(octokit, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission, user) {
+async function commit(octokit, user, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission) {
   const name = normalizeName(submission.title);
   log(`Committing solution for ${name}...`);
 
@@ -115,7 +115,7 @@ function addToSubmissions(response, lastTimestamp, filterDuplicateSecs, submissi
   return true;
 }
 
-async function sync(githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession) {
+async function sync(user, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession) {
   const octokit = new Octokit({
     auth: githubToken,
     userAgent: 'LeetCode sync to GitHub - GitHub Action',
@@ -205,7 +205,7 @@ async function sync(githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFT
   let treeSHA = commits.data[0].commit.tree.sha;
   for (i = submissions.length - 1; i >= 0; i--) {
     submission = submissions[i];
-    [treeSHA, latestCommitSHA] = await commit(octokit, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission);
+    [treeSHA, latestCommitSHA] = await commit(octokit, user, owner, repo, defaultBranch, commitInfo, treeSHA, latestCommitSHA, submission);
   }
   log('Done syncing all submissions.');
 }
@@ -219,7 +219,7 @@ async function main() {
   const leetcodeSession = core.getInput('leetcode-session');
   const filterDuplicateSecs = core.getInput('filter-duplicate-secs');
 
-  await sync(githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession);
+  await sync(user, githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession);
 }
 
 main().catch((error) => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cherrykatatonic-leetcode-sync",
+  "name": "leetcode-sync",
   "version": "1.4.0",
   "description": "Forked GitHub Action for syncing LeetCode submissions to a git repository",
   "main": "index.js",
@@ -8,15 +8,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cherrykatatonic/leetcode-sync.git"
+    "url": "git+https://github.com/joshcai/leetcode-sync.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cherrykatatonic/leetcode-sync/issues"
+    "url": "https://github.com/joshcai/leetcode-sync/issues"
   },
-  "homepage": "https://github.com/cherrykatatonic/leetcode-sync#readme",
+  "homepage": "https://github.com/joshcai/leetcode-sync#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leetcode-sync",
-  "version": "1.4.0",
+  "version": "1.0.0",
   "description": "GitHub Action for syncing LeetCode submissions to a git repository",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cherrykatatonic-leetcode-sync",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "description": "Forked GitHub Action for syncing LeetCode submissions to a git repository",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "leetcode-sync",
+  "name": "cherrykatatonic-leetcode-sync",
   "version": "1.0.0",
-  "description": "GitHub Action for syncing LeetCode submissions to a git repository",
+  "description": "Forked GitHub Action for syncing LeetCode submissions to a git repository",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joshcai/leetcode-sync.git"
+    "url": "git+https://github.com/cherrykatatonic/leetcode-sync.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/joshcai/leetcode-sync/issues"
+    "url": "https://github.com/cherrykatatonic/leetcode-sync/issues"
   },
-  "homepage": "https://github.com/joshcai/leetcode-sync#readme",
+  "homepage": "https://github.com/cherrykatatonic/leetcode-sync#readme",
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "leetcode-sync",
   "version": "1.4.0",
-  "description": "Forked GitHub Action for syncing LeetCode submissions to a git repository",
+  "description": "GitHub Action for syncing LeetCode submissions to a git repository",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This change adds the _optional_ `destination-folder` input field to the workflow definition to allow the user to specify a subfolder within their repo to sync their LeetCode submissions to. This is useful for users who want to share a repo with others to add a more social, collaborative, or competitive aspect to their LeetCode repo.