### PR TITLE
Add support for elixir language

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -8,6 +8,7 @@ const LANG_TO_EXTENSION = {
   'cpp': 'cpp',
   'csharp': 'cs',
   'dart': 'dart',
+  'elixir': 'ex',
   'golang': 'go',
   'java': 'java',
   'javascript': 'js',


### PR DESCRIPTION
Current GitHub Actions fail with the following message:

`Error: Language elixir does not have a registered extension.`