### PR TITLE
Add verbose and commit-header functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
              leetcode-csrf-token: ${{ secrets.LEETCODE_CSRF_TOKEN }}
              leetcode-session: ${{ secrets.LEETCODE_SESSION }}
              destination-folder: my-folder
+             verbose: true
+             commit-header: '[LeetCode Sync]'
    ```
 
 6. After you've submitted a LeetCode solution, run the workflow by going to the `Actions` tab, clicking the action name, e.g. `Sync Leetcode`, and then clicking `Run workflow`. The workflow will also automatically run once a week by default (can be configured via the `cron` parameter).
@@ -64,17 +66,19 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 - `leetcode-csrf-token` _(required)_: The LeetCode CSRF token for retrieving submissions from LeetCode
 - `leetcode-session` _(required)_: The LeetCode session value for retrieving submissions from LeetCode
 - `filter-duplicate-secs`: Number of seconds after an accepted solution to ignore other accepted solutions for the same problem, default: 86400 (1 day)
-- `destination-folder` _(optional)_: The folder in your repo to save the submissions to (necessary for shared repos)
+- `destination-folder` _(optional)_: The folder in your repo to save the submissions to (necessary for shared repos), default: _none_
+- `verbose` _(optional)_: Requires an additional API call but adds submission percentiles and question numbers to the repo, default: true
+- `commit-header` _(optional)_: How the automated commits should be prefixed, default: '[LeetCode Sync]'
 
 ## Shared Repos
 
-A single repo can be shared by multiple users by using the `destination-folder` input field to sync each user's files to a separate folder. This is useful for users who want to add a more social, collaborative, or competitive aspect to their LeetCode sync repo.
+Problems can be routed to a specific folder within a single repo using the `destination-folder` input field. This is useful for users who want to share a repo to add a more social, collaborative, or competitive aspect to their LeetCode sync repo.
 
 ## Contributing
 
 #### Testing locally
 
-If you want to test changes to the action locally without having to commit and run the workflow on GitHub, you can edit `src/test_config.js` to have the required config values and then run: 
+If you want to test changes to the action locally without having to commit and run the workflow on GitHub, you can edit `src/test_config.js` to have the required config values and then run:
 
 `$ node index.js test`
 
@@ -82,7 +86,7 @@ If you're using Replit, you can also just use the `Run` button, which is already
 
 #### Adding a new workflow parameter
 
-If you add a workflow parameter, please make sure to also add it in `src/test_config.js`, so that it can be tested locally. 
+If you add a workflow parameter, please make sure to also add it in `src/test_config.js`, so that it can be tested locally.
 
 You will need to manually run:
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ GitHub Action for automatically syncing LeetCode submissions to a GitHub reposit
 - `leetcode-session` _(required)_: The LeetCode session value for retrieving submissions from LeetCode
 - `filter-duplicate-secs`: Number of seconds after an accepted solution to ignore other accepted solutions for the same problem, default: 86400 (1 day)
 - `destination-folder` _(optional)_: The folder in your repo to save the submissions to (necessary for shared repos), default: _none_
-- `verbose` _(optional)_: Requires an additional API call but adds submission percentiles and question numbers to the repo, default: true
-- `commit-header` _(optional)_: How the automated commits should be prefixed, default: '[LeetCode Sync]'
+- `verbose` _(optional)_: Adds submission percentiles and question numbers to the repo (requires an additional API call), default: true
+- `commit-header` _(optional)_: How the automated commits should be prefixed, default: 'Sync LeetCode submission'
 
 ## Shared Repos
 

--- a/action.yml
+++ b/action.yml
@@ -22,13 +22,13 @@ inputs:
     required: false
     default: null
   verbose:
-    description: 'Requires an additional API call but adds submission percentiles and question numbers to the repo'
+    description: 'Adds submission percentiles and question numbers to the repo (requires an additional API call)'
     required: false
     default: true
   commit-header:
     description: 'How the automated commits should be prefixed'
     required: false
-    default: '[LeetCode Sync]'
+    default: 'Sync LeetCode submission'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'LeetCode Sync'
 description: 'Sync LeetCode submissions to GitHub'
-branding: 
+branding:
   icon: git-commit
   color: yellow
 inputs:
@@ -20,6 +20,15 @@ inputs:
   destination-folder:
     description: 'The folder to save the synced files in (relative to the top level of your repo)'
     required: false
+    default: null
+  verbose:
+    description: 'Requires an additional API call but adds submission percentiles and question numbers to the repo'
+    required: false
+    default: true
+  commit-header:
+    description: 'How the automated commits should be prefixed'
+    required: false
+    default: '[LeetCode Sync]'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ async function main() {
     leetcodeSession = config.LEETCODE_SESSION;
     filterDuplicateSecs = config.FILTER_DUPLICATE_SECS;
     destinationFolder = config.DESTINATION_FOLDER;
+    verbose = config.VERBOSE;
+    commitHeader = config.COMMIT_HEADER;
   } else {
     githubToken = core.getInput('github-token');
     owner = context.repo.owner;
@@ -26,9 +28,11 @@ async function main() {
     leetcodeSession = core.getInput('leetcode-session');
     filterDuplicateSecs = core.getInput('filter-duplicate-secs');
     destinationFolder = core.getInput('destination-folder');
+    verbose = core.getInput('verbose');
+    commitHeader = core.getInput('commit-header');
   }
 
-  await action.sync({ githubToken, owner, repo, filterDuplicateSecs, leetcodeCSRFToken, leetcodeSession, destinationFolder });
+  await action.sync({ githubToken, owner, repo, leetcodeCSRFToken, leetcodeSession, filterDuplicateSecs, destinationFolder, verbose, commitHeader });
 }
 
 main().catch((error) => {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ async function main() {
     leetcodeSession = config.LEETCODE_SESSION;
     filterDuplicateSecs = config.FILTER_DUPLICATE_SECS;
     destinationFolder = config.DESTINATION_FOLDER;
-    verbose = config.VERBOSE;
+    verbose = config.VERBOSE.toString();  // Convert to string to match core.getInput('verbose') return type
     commitHeader = config.COMMIT_HEADER;
   } else {
     githubToken = core.getInput('github-token');

--- a/src/action.js
+++ b/src/action.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const { Octokit } = require('@octokit/rest');
 
-const COMMIT_MESSAGE = '[LeetCode Sync]';
+const COMMIT_MESSAGE = 'Sync LeetCode submission';
 const LANG_TO_EXTENSION = {
   'bash': 'sh',
   'c': 'c',
@@ -34,6 +34,9 @@ function log(message) {
 }
 
 function pad(n) {
+    if (n.length > 4) {
+        return n;
+    }
     var s = '000' + n;
     return s.substring(s.length-4);
 }
@@ -74,7 +77,7 @@ async function getInfo(submission, session, csrf) {
       const questionId = pad(response.data.data.submissionDetails.question.questionId.toString());
 
       log(`Got info for submission #${submission.id}`);
-      return { runtimeperc: runtimePercentile, memoryperc: memoryPercentile, qid: questionId };
+      return { runtimePerc: runtimePercentile, memoryPerc: memoryPercentile, qid: questionId };
     } catch (exception) {
       if (retryCount >= maxRetries) {
         throw exception;
@@ -114,8 +117,8 @@ async function commit(params) {
   const prefix = !!destinationFolder ? `${destinationFolder}/` : '';
   const commitName = !!commitHeader ? commitHeader : COMMIT_MESSAGE;
 
-  if ('runtimeperc' in submission) {
-    message = `${commitName} Runtime - ${submission.runtime} (${submission.runtimeperc}), Memory - ${submission.memory} (${submission.memoryperc})`;
+  if ('runtimePerc' in submission) {
+    message = `${commitName} Runtime - ${submission.runtime} (${submission.runtimePerc}), Memory - ${submission.memory} (${submission.memoryPerc})`;
     qid = `${submission.qid}-`;
   } else {
     message = `${commitName} Runtime - ${submission.runtime}, Memory - ${submission.memory}`;

--- a/src/test_config.js
+++ b/src/test_config.js
@@ -1,14 +1,15 @@
 // Modify this file to run index.js locally and not as a GitHub Action.
 
 module.exports = {
+  // These parameters are required.
   GITHUB_TOKEN: null,
-  // Form of "<owner>/<repo_name>"
-  GITHUB_REPO: null,
-  
+  GITHUB_REPO: null,  // Form of '<owner>/<repo_name>'
   LEETCODE_CSRF_TOKEN: null,
   LEETCODE_SESSION: null,
 
-  // These parameters are optional and have default values.
+  // These parameters are optional and have default values if needed.
   FILTER_DUPLICATE_SECS: 86400,
   DESTINATION_FOLDER: null,
+  VERBOSE: true,
+  COMMIT_HEADER: '[LeetCode Sync]'
 }

--- a/src/test_config.js
+++ b/src/test_config.js
@@ -11,5 +11,5 @@ module.exports = {
   FILTER_DUPLICATE_SECS: 86400,
   DESTINATION_FOLDER: null,
   VERBOSE: true,
-  COMMIT_HEADER: '[LeetCode Sync]'
+  COMMIT_HEADER: 'Sync LeetCode submission'
 }


### PR DESCRIPTION
# Verbose
Added an option to display additional information about submissions in commit logs and folder names.

# Commit header
The prefix for automated commits is now changeable. I made some other changes to commit formatting that serve to reduce redundancy and provide more novel information about each commit while still keeping the automated messages reasonably concise.

# Folders
I also made it optional to always put problems into their own repo (so that each submission folder can be in the repo's base directory if desired, while still potentially segregating submissions into per-user repos for collaboration).

# Miscellaneous
There are also some small tweaks like adding newlines at the end of submission files - recommended for git, but not added automatically by Leetcode. Some diffs are also caused by my Vim config stripping spaces from the end of lines or adding newlines at the bottoms of code files.

# Other
The README yaml example might need updating with a new tag if this is merged. Not sure but didn't want to add a new release/tag myself.

# Images:
The screenshot below was generated by this yaml (linked to my fork for testing):
```yaml
name: Sync Leetcode

on:
  workflow_dispatch:
  schedule:
    - cron: "0 0 * * *"

jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - name: Sync
        uses: ravibrock/leetcode-sync@v1.6
        with:
          github-token: ${{ github.token }}
          leetcode-csrf-token: ${{ secrets.CSRFTOKEN }}
          leetcode-session: ${{ secrets.LEETCODE_SESSION }}
          verbose: true
          commit-header: '[LC Sync]'
```
![Screenshot 2023-08-10 at 18 07 31](https://github.com/joshcai/leetcode-sync/assets/66334356/6c02aa1c-6701-4882-af97-7f9894b5ee9b)

And the last screenshot by this one:
```yaml
name: Sync Leetcode

on:
  workflow_dispatch:
  schedule:
    - cron: "0 0 * * *"

jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - name: Sync
        uses: ravibrock/leetcode-sync@v1.6
        with:
          github-token: ${{ github.token }}
          leetcode-csrf-token: ${{ secrets.CSRFTOKEN }}
          leetcode-session: ${{ secrets.LEETCODE_SESSION }}
          destination-folder: 'problems'
          verbose: false
          commit-header: '[LC Sync]'
```
![Screenshot 2023-08-10 at 18 43 35](https://github.com/joshcai/leetcode-sync/assets/66334356/3d053aa6-47e6-4f6e-a280-720f139638e1)