### PR TITLE
Fix error while committing a locked problem with an accepted solution.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 npm run package
-git add .
+git add dist/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -14654,7 +14654,7 @@ async function commit(params) {
     {
       path: path.normalize(questionPath),
       mode: "100644",
-      content: `${questionData}`,
+      content: questionData ?? "Unable to fetch the Problem statement.",
     },
     {
       path: path.normalize(solutionPath),

--- a/dist/index.js
+++ b/dist/index.js
@@ -14654,7 +14654,7 @@ async function commit(params) {
     {
       path: path.normalize(questionPath),
       mode: "100644",
-      content: questionData,
+      content: `${questionData}`,
     },
     {
       path: path.normalize(solutionPath),

--- a/src/action.js
+++ b/src/action.js
@@ -165,7 +165,7 @@ async function commit(params) {
     {
       path: path.normalize(questionPath),
       mode: "100644",
-      content: questionData,
+      content: `${questionData}`,
     },
     {
       path: path.normalize(solutionPath),

--- a/src/action.js
+++ b/src/action.js
@@ -165,7 +165,7 @@ async function commit(params) {
     {
       path: path.normalize(questionPath),
       mode: "100644",
-      content: `${questionData}`,
+      content: questionData ?? "Unable to fetch the Problem statement.",
     },
     {
       path: path.normalize(solutionPath),


### PR DESCRIPTION
Came across the below error on a recent run:
```
[Sun, 28 Apr 2024 19:56:01 GMT] Syncing 1480 submissions...
[Sun, 28 Apr 2024 19:56:01 GMT] Got info for submission #321203125
[Sun, 28 Apr 2024 19:56:01 GMT] Getting question data for counting-elements...
[Sun, 28 Apr 2024 19:56:01 GMT] Committing solution for counting-elements...
[Sun, 28 Apr 2024 19:56:01 GMT] HttpError: Must supply either tree.sha or tree.content. Request will be rejected if both are present.
    at /home/runner/work/_actions/joshcai/leetcode-sync/v1.6/dist/index.js:6540:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async commit (/home/runner/work/_actions/joshcai/leetcode-sync/v1.6/dist/index.js:14666:24)
    at async Object.sync (/home/runner/work/_actions/joshcai/leetcode-sync/v1.6/dist/index.js:14914:34)
    at async main (/home/runner/work/_actions/joshcai/leetcode-sync/v1.6/dist/index.js:19564:3)
Error: HttpError: Must supply either tree.sha or tree.content. Request will be rejected if both are present.
```

Turns out the problem [counting-elements](https://leetcode.com/problems/counting-elements/description/) is a locked/premium problem. As a consequence, fetching the `questionData` yields `null`, which then leads to an empty `tree.content` in the commit, causing the above error.

Interestingly, I do seem to have an accepted solution for the problem in my submission history.
And, No, I wasn't on leetcode premium in the past.

I'm guessing, `counting-elements` started off as an open problem, but was locked sometime after I'd solved it.

As a hotfix for my personal use, I've wrapped `questionData` in a template literal. Please feel free to add appropriate fallback text and logs as you deem fit.

Also, shot myself in the foot with the `git add .` in the pre-commit. Hence a tiny tweak.

PS. Thanks for the good work, Josh. Very nifty tool!