### PR TITLE
handle expired leetcode session error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -14521,7 +14521,7 @@ const LANG_TO_EXTENSION = {
 };
 const BASE_URL = "https://leetcode.com";
 
-const delay = (ms) => new Promise((res) => setTimeout(res, ms));
+const delay = ms => new Promise(res => setTimeout(res, ms));
 
 function log(message) {
   console.log(`[${new Date().toUTCString()}] ${message}`);
@@ -14756,6 +14756,13 @@ function addToSubmissions(params) {
     submissions,
   } = params;
 
+  if (!response?.data?.data?.submissionList?.submissions) {
+    throw new Error(
+      "No LeetCode submissions found. This may be caused by an expired session. " +
+        "Please check if your LEETCODE_SESSION environment variable is valid and up to date."
+    );
+  }
+
   for (const submission of response.data.data.submissionList.submissions) {
     submissionTimestamp = Number(submission.timestamp);
     if (submissionTimestamp <= lastTimestamp) {
@@ -14864,6 +14871,7 @@ async function sync(inputs) {
           graphql,
           { headers }
         );
+
         log(`Successfully fetched submission from LeetCode, offset ${offset}`);
         return response;
       } catch (exception) {

--- a/src/action.js
+++ b/src/action.js
@@ -32,7 +32,7 @@ const LANG_TO_EXTENSION = {
 };
 const BASE_URL = "https://leetcode.com";
 
-const delay = (ms) => new Promise((res) => setTimeout(res, ms));
+const delay = ms => new Promise(res => setTimeout(res, ms));
 
 function log(message) {
   console.log(`[${new Date().toUTCString()}] ${message}`);
@@ -267,6 +267,13 @@ function addToSubmissions(params) {
     submissions,
   } = params;
 
+  if (!response?.data?.data?.submissionList?.submissions) {
+    throw new Error(
+      "No LeetCode submissions found. This may be caused by an expired session. " +
+        "Please check if your LEETCODE_SESSION environment variable is valid and up to date."
+    );
+  }
+
   for (const submission of response.data.data.submissionList.submissions) {
     submissionTimestamp = Number(submission.timestamp);
     if (submissionTimestamp <= lastTimestamp) {
@@ -375,6 +382,7 @@ async function sync(inputs) {
           graphql,
           { headers }
         );
+
         log(`Successfully fetched submission from LeetCode, offset ${offset}`);
         return response;
       } catch (exception) {


### PR DESCRIPTION
I ran into an issue where the github action stopped working after some time and was giving me this error:

`TypeError: response.data.data.submissionList.submissions is not iterable`

After debugging, the cause was that my leetcode session had expired causing the submissions to be null. I have added a check against this case that will show an error message instead attempting to iterate over null submissions. Workflow should now show a message telling the user their session may have expired if no submissions are being returned from the leetcode api, rather than throwing the previous type error. 